### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -39,7 +39,7 @@ jobs:
       run: cp public/robots.txt.development public/robots.txt
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: standardnotes/web
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -39,7 +39,7 @@ jobs:
       run: cp public/robots.txt.production public/robots.txt
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: standardnotes/web
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore